### PR TITLE
Сontinuation of stopping the queue cluster

### DIFF
--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -102,12 +102,12 @@ type ClusterQueueSpec struct {
 	//
 	// Depending on its value, its associated workloads will:
 	//
-	// - StopNow - Admitted workloads are evicted and Reserving workloads will cancel the reservation.
-	// - WaitForAdmitted - Admitted workloads will run to completion and Reserving workloads will cancel the reservation.
-	// - WaitForAdmitted - Admitted and Reserving workloads will run to completion.
+	// - None - Workloads are admitted
+	// - HoldAndDrain - Admitted workloads are evicted and Reserving workloads will cancel the reservation.
+	// - Hold - Admitted workloads will run to completion and Reserving workloads will cancel the reservation.
 	//
 	// +optional
-	// +kubebuilder:validation:Enum=StopNow;WaitForAdmitted;WaitForReserving
+	// +kubebuilder:validation:Enum=None;Hold;HoldAndDrain
 	StopPolicy StopPolicy `json:"stopPolicy,omitempty"`
 }
 
@@ -128,9 +128,9 @@ const (
 type StopPolicy string
 
 const (
-	StopNow          StopPolicy = "StopNow"
-	WaitForAdmitted  StopPolicy = "WaitForAdmitted"
-	WaitForReserving StopPolicy = "WaitForReserving"
+	None         StopPolicy = "None"
+	HoldAndDrain StopPolicy = "HoldAndDrain"
+	Hold         StopPolicy = "Hold"
 )
 
 type ResourceGroup struct {

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -335,15 +335,14 @@ spec:
               stopPolicy:
                 description: "stopPolicy - if set the ClusterQueue is considered Inactive,
                   no new reservation being made. \n Depending on its value, its associated
-                  workloads will: \n - StopNow - Admitted workloads are evicted and
-                  Reserving workloads will cancel the reservation. - WaitForAdmitted
-                  - Admitted workloads will run to completion and Reserving workloads
-                  will cancel the reservation. - WaitForAdmitted - Admitted and Reserving
-                  workloads will run to completion."
+                  workloads will: \n - None - Workloads are admitted - HoldAndDrain
+                  - Admitted workloads are evicted and Reserving workloads will cancel
+                  the reservation. - Hold - Admitted workloads will run to completion
+                  and Reserving workloads will cancel the reservation."
                 enum:
-                - StopNow
-                - WaitForAdmitted
-                - WaitForReserving
+                - None
+                - Hold
+                - HoldAndDrain
                 type: string
             type: object
           status:

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -322,15 +322,14 @@ spec:
               stopPolicy:
                 description: "stopPolicy - if set the ClusterQueue is considered Inactive,
                   no new reservation being made. \n Depending on its value, its associated
-                  workloads will: \n - StopNow - Admitted workloads are evicted and
-                  Reserving workloads will cancel the reservation. - WaitForAdmitted
-                  - Admitted workloads will run to completion and Reserving workloads
-                  will cancel the reservation. - WaitForAdmitted - Admitted and Reserving
-                  workloads will run to completion."
+                  workloads will: \n - None - Workloads are admitted - HoldAndDrain
+                  - Admitted workloads are evicted and Reserving workloads will cancel
+                  the reservation. - Hold - Admitted workloads will run to completion
+                  and Reserving workloads will cancel the reservation."
                 enum:
-                - StopNow
-                - WaitForAdmitted
-                - WaitForReserving
+                - None
+                - Hold
+                - HoldAndDrain
                 type: string
             type: object
           status:

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -230,7 +230,7 @@ func (r *WorkloadReconciler) reconcileOnClusterQueueActiveState(ctx context.Cont
 
 	log := ctrl.LoggerFrom(ctx)
 	if workload.IsAdmitted(wl) {
-		if err != nil || queue.Spec.StopPolicy != kueue.StopNow || apimeta.IsStatusConditionTrue(wl.Status.Conditions, kueue.AdmissionCheckActive) {
+		if err != nil || queue.Spec.StopPolicy != kueue.HoldAndDrain || apimeta.IsStatusConditionTrue(wl.Status.Conditions, kueue.AdmissionCheckActive) {
 			return false, nil
 		}
 		log.V(3).Info("Workload is evicted because the ClusterQueue is stopped", "clusterQueue", klog.KRef("", cqName))
@@ -245,7 +245,7 @@ func (r *WorkloadReconciler) reconcileOnClusterQueueActiveState(ctx context.Cont
 		return true, workload.ApplyAdmissionStatus(ctx, r.client, wl, true)
 	}
 
-	if queue.Spec.StopPolicy == kueue.StopNow || queue.Spec.StopPolicy == kueue.WaitForAdmitted {
+	if queue.Spec.StopPolicy == kueue.HoldAndDrain || queue.Spec.StopPolicy == kueue.Hold {
 		log.V(3).Info("Workload is inadmissible because the ClusterQueue is stopped", "clusterQueue", klog.KRef("", cqName))
 		workload.UnsetQuotaReservationWithCondition(wl, "Inadmissible", fmt.Sprintf("ClusterQueue %s is terminating or missing", cqName))
 		return true, workload.ApplyAdmissionStatus(ctx, r.client, wl, true)

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package scheduler
 
 import (
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -1389,5 +1391,85 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.Entry("request under pod limits", testParams{reqCPU: "2", limitCPU: "3", minCPU: "3", limitType: corev1.LimitTypePod, wantedStatus: "didn't satisfy LimitRange constraints:"}),
 			ginkgo.Entry("valid", testParams{reqCPU: "2", limitCPU: "3", minCPU: "1", maxCPU: "4", shouldBeAdmited: true}),
 		)
+	})
+
+	ginkgo.When("Using clusterQueue stop policy", func() {
+		var (
+			cq    *kueue.ClusterQueue
+			queue *kueue.LocalQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			gomega.Expect(k8sClient.Create(ctx, onDemandFlavor)).Should(gomega.Succeed())
+			cq = testing.MakeClusterQueue("cluster-queue").
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("on-demand").
+						Resource(corev1.ResourceCPU, "5", "5").Obj(),
+				).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
+			queue = testing.MakeLocalQueue("queue", ns.Name).ClusterQueue(cq.Name).Obj()
+			gomega.Expect(k8sClient.Create(ctx, queue)).To(gomega.Succeed())
+		})
+
+		ginkgo.AfterEach(func() {
+			util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, cq, true)
+			util.ExpectResourceFlavorToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
+		})
+
+		ginkgo.It("Should evict workloads when we apply stop policy is drain", func() {
+			ginkgo.By("Creating workload")
+			wl := testing.MakeWorkload("one", ns.Name).Queue(queue.Name).Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, wl)
+			util.ExpectReservingActiveWorkloadsMetric(cq, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
+
+			ginkgo.By("Stop clusterQueue's with drain")
+			var clusterQueue kueue.ClusterQueue
+			gomega.Eventually(func() error {
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &clusterQueue)).To(gomega.Succeed())
+				clusterQueue.Spec.StopPolicy = kueue.HoldAndDrain
+				return k8sClient.Update(ctx, &clusterQueue)
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Checking the condition of workload is evicted", func() {
+				createdWl := kueue.Workload{}
+				gomega.Eventually(func() *metav1.Condition {
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &createdWl)).To(gomega.Succeed())
+					return apimeta.FindStatusCondition(createdWl.Status.Conditions, kueue.WorkloadEvicted)
+				}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(&metav1.Condition{
+					Type:    kueue.WorkloadEvicted,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueue.WorkloadEvictedByClusterQueueStop,
+					Message: "The ClusterQueue is stopped",
+				}, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")))
+			})
+
+			util.FinishEvictionForWorkloads(ctx, k8sClient, wl)
+
+			ginkgo.By("Restart clusterQueue's policy")
+			gomega.Eventually(func() error {
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &clusterQueue)).To(gomega.Succeed())
+				clusterQueue.Spec.StopPolicy = ""
+				return k8sClient.Update(ctx, &clusterQueue)
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Verify the workload should be readmitted", func() {
+				createdWl := kueue.Workload{}
+				gomega.Eventually(func() *metav1.Condition {
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &createdWl)).To(gomega.Succeed())
+					return apimeta.FindStatusCondition(createdWl.Status.Conditions, kueue.WorkloadAdmitted)
+				}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(&metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueue.WorkloadAdmitted,
+					Message: "The workload is admitted",
+				}, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")))
+			})
+			util.ExpectReservingActiveWorkloadsMetric(cq, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq, 2)
+			util.FinishWorkloads(ctx, k8sClient, wl)
+		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1284 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```